### PR TITLE
Filter repositories that contains good first issues

### DIFF
--- a/server/src/github/client.rs
+++ b/server/src/github/client.rs
@@ -50,8 +50,8 @@ impl GithubHttpClient {
         })
     }
 
-    #[tracing::instrument(name = "Get Rust repositories from Github API", skip(self))]
-    pub async fn get_rust_repositories(
+    #[tracing::instrument(name = "Getrepositories from Github API", skip(self))]
+    pub async fn get_repositories(
         &self,
         params: &GetGithubRepositoriesParams,
     ) -> Result<GetGithubRepositoriesResponse, RustGoodFirstIssuesError> {
@@ -61,7 +61,10 @@ impl GithubHttpClient {
             .map_err(RustGoodFirstIssuesError::ParseUrl)?;
 
         url.query_pairs_mut()
-            .append_pair("q", format!("language:{}", params.language).as_str())
+            .append_pair(
+                "q",
+                format!("language:{} good-first-issues:>1", params.language).as_str(),
+            )
             .append_pair("sort", "help-wanted-issues")
             .append_pair("order", "desc")
             .append_pair(

--- a/server/src/github/handlers.rs
+++ b/server/src/github/handlers.rs
@@ -24,7 +24,7 @@ pub async fn get_repositories(
     let params = params.0;
     let github_client = GithubHttpClient::new(state.github_settings.clone())?;
 
-    let res = github_client.get_rust_repositories(&params).await?;
+    let res = github_client.get_repositories(&params).await?;
 
     return Ok((StatusCode::OK, Json(res)).into_response());
 }


### PR DESCRIPTION
Improves the way how repositories are retrieve.

By adding the query `good-first-issues:>1`, we make sure that all repositories that we get throught the `/api/v1/github/repositories` contains at least one good first issues. If you want to know more about why this filter is necessary, you can check the [Github Searching for repositories docs](https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories#search-based-on-number-of-issues-with-good-first-issue-or-help-wanted-labels).
